### PR TITLE
perf: keep filename stable

### DIFF
--- a/build/config/splitChunks.js
+++ b/build/config/splitChunks.js
@@ -24,19 +24,19 @@ module.exports = {
       chunks: 'initial',
     },
     route: {
-      filename: utils.assetsPath('js/route.[hash:24].js'),
+      filename: utils.assetsPath('js/route.[chunkhash:24].js'),
       name: 'route',
       test: /[\\/]src[\\/](router)[\\/]/,
       chunks: 'initial',
     },
     store: {
-      filename: utils.assetsPath('js/store.[hash:24].js'),
+      filename: utils.assetsPath('js/store.[chunkhash:24].js'),
       name: 'store',
       test: /[\\/]src[\\/](store)[\\/]/,
       chunks: 'initial',
     },
     vendor: {
-      filename: utils.assetsPath('js/vendor.[hash:24].js'),
+      filename: utils.assetsPath('js/vendor.[chunkhash:24].js'),
       name: 'vendor',
       test: /node_modules/,
       chunks: 'initial',

--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -17,6 +17,8 @@ const config = require('./config');
 const splitChunks = require('./config/splitChunks');
 const ts = require('typescript');
 console.log('TypeScript Version: ' + ts.version );
+const seen = new Set();
+const nameLength = 4;
 const webpackConfig = {
   entry: {
     app: './src/main.ts',
@@ -110,8 +112,23 @@ const webpackConfig = {
         return env;
       })(),
     }),
-    // keep module.id stable when vendor modules does not change
-    new webpack.NamedChunksPlugin(),
+    // https://github.com/vuejs/vue-cli/issues/1916#issuecomment-407693467
+    // https://segmentfault.com/a/1190000015919928#articleHeader10
+    new webpack.NamedChunksPlugin(chunk => {
+      if (chunk.name) {
+        return chunk.name;
+      }
+      const modules = Array.from(chunk.modulesIterable);
+      if (modules.length > 1) {
+        const hash = require('hash-sum');
+        const joinedHash = hash(modules.map(m => m.id).join('_'));
+        let len = nameLength;
+        while (seen.has(joinedHash.substr(0, len))) len++;
+        seen.add(joinedHash.substr(0, len));
+        return `chunk-${joinedHash.substr(0, len)}`;
+      }
+      return modules[0].id;
+    }),
     new webpack.HashedModuleIdsPlugin(),
     // generate dist index.html with correct asset hash for caching.
     // you can customize output by editing /index.html

--- a/build/webpack.prod.conf.js
+++ b/build/webpack.prod.conf.js
@@ -23,7 +23,7 @@ const webpackConfig = merge(webpackBaseConfig, {
       analyzerMode: 'static',
     }),
     new MiniCssExtractPlugin({
-      filename: utils.assetsPath('css/[name].[chunkhash].css'),
+      filename: utils.assetsPath('css/[name].[contenthash].css'),
     }),
     // copy custom static assets
     new CopyWebpackPlugin([


### PR DESCRIPTION
1. 在我项目里面vendor.[hash]每次都会变，改成chunkhash才稳定
2. chunkId参考了注释中的链接  
3. css用contenthash是因为考虑到，css修改频率低于js，不必跟着chunkhash变化。